### PR TITLE
Add run.toml

### DIFF
--- a/.lapce/run.toml
+++ b/.lapce/run.toml
@@ -1,0 +1,4 @@
+[[configs]]
+name = "Plugin"
+program = "${lapce}"
+args = ["--plugin-path=${workspace}", "--wait", "--new"]


### PR DESCRIPTION
This adds a `run.toml` to launch the plugin within Lapce for easier development.  
Currently, it still requires manually building & copying the wasm file though I hope to improve that later.